### PR TITLE
Expand test suite from 2 smoke tests to 78 tests with 100% coverage

### DIFF
--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,64 @@
+import pytest
+from pydantic import ValidationError
+
+from givenergy_api_client.account import Account
+
+VALID_ACCOUNT_DATA = {
+    "id": 2,
+    "name": "frank28.203",
+    "first_name": "Anna",
+    "surname": "Adams",
+    "role": "OWNER",
+    "email": "kelly44@allen.co.uk",
+    "address": "Flat 60\nKyle Lights",
+    "postcode": "SP1 1NE",
+    "country": "UNITED_KINGDOM",
+    "telephone_number": "0738 286 7656",
+    "timezone": "GMT",
+    "standard_timezone": "Europe/London",
+}
+
+
+class TestAccountModel:
+
+    def test_valid_construction(self) -> None:
+        account = Account.model_validate(VALID_ACCOUNT_DATA)
+        assert account.id == 2
+        assert account.name == "frank28.203"
+        assert account.first_name == "Anna"
+        assert account.surname == "Adams"
+        assert account.role == "OWNER"
+        assert account.email == "kelly44@allen.co.uk"
+        assert account.address == "Flat 60\nKyle Lights"
+        assert account.postcode == "SP1 1NE"
+        assert account.country == "UNITED_KINGDOM"
+        assert account.telephone_number == "0738 286 7656"
+        assert account.timezone == "GMT"
+        assert account.standard_timezone == "Europe/London"
+
+    def test_is_immutable(self) -> None:
+        account = Account.model_validate(VALID_ACCOUNT_DATA)
+        with pytest.raises(ValidationError):
+            account.first_name = "Changed"  # type: ignore[misc]
+
+    def test_invalid_email_raises(self) -> None:
+        bad_data = {**VALID_ACCOUNT_DATA, "email": "not-an-email"}
+        with pytest.raises(ValidationError):
+            Account.model_validate(bad_data)
+
+    def test_missing_required_field_raises(self) -> None:
+        for field in VALID_ACCOUNT_DATA:
+            incomplete = {k: v for k, v in VALID_ACCOUNT_DATA.items() if k != field}
+            with pytest.raises(ValidationError):
+                Account.model_validate(incomplete)
+
+    def test_id_must_be_int(self) -> None:
+        bad_data = {**VALID_ACCOUNT_DATA, "id": "not-an-int"}
+        with pytest.raises(ValidationError):
+            Account.model_validate(bad_data)
+
+    def test_email_domain_is_normalised_to_lowercase(self) -> None:
+        data = {**VALID_ACCOUNT_DATA, "email": "User@Example.COM"}
+        account = Account.model_validate(data)
+        # Pydantic normalises the domain to lowercase but preserves the local part
+        assert account.email == "User@example.com"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,86 +1,417 @@
+import datetime as dt
+
+import httpx
+import pytest
 from pytest_httpx import HTTPXMock
 
-from givenergy_api_client.client import GivenergyAPIClient
+from givenergy_api_client.client import (
+    EnergyDataFlowGrouping,
+    EnergyDataFlowType,
+    GivenergyAPIClient,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+ACCOUNT_PAYLOAD = {
+    "id": 2,
+    "name": "frank28.203",
+    "first_name": "Anna",
+    "surname": "Adams",
+    "role": "OWNER",
+    "email": "kelly44@allen.co.uk",
+    "address": "Flat 60\nKyle Lights",
+    "postcode": "SP1 1NE",
+    "country": "UNITED_KINGDOM",
+    "telephone_number": "0738 286 7656",
+    "timezone": "GMT",
+    "standard_timezone": "Europe/London",
+}
+
+COMMUNICATION_DEVICE_PAYLOAD = {
+    "serial_number": "WF2345G123",
+    "type": "WIFI",
+    "firmware_version": 123,
+    "commission_date": "2021-01-01T00:00:00Z",
+    "inverter": {
+        "serial": "CE2345G123",
+        "status": "WAITING",
+        "last_online": "2023-01-01T00:00:00Z",
+        "last_updated": "2023-01-01T00:00:00Z",
+        "commission_date": "2021-01-01T00:00:00Z",
+        "info": {
+            "battery_type": "LITHIUM",
+            "battery": {"nominal_capacity": 110, "nominal_voltage": 51.2, "depth_of_discharge": 1},
+            "model": "GIV-AC-3.0",
+            "max_charge_rate": 2560,
+        },
+        "warranty": {"type": "Standard", "expiry_date": "2033-01-01T00:00:00Z"},
+        "firmware_version": {"ARM": 420, "DSP": 426},
+        "connections": {
+            "batteries": [
+                {
+                    "module_number": 1,
+                    "serial": "BB2345G123",
+                    "firmware_version": 1035,
+                    "capacity": {"full": 110, "design": 110},
+                    "cell_count": 16,
+                    "has_usb": True,
+                    "nominal_voltage": 51.2,
+                }
+            ],
+            "meters": [
+                {
+                    "address": 1,
+                    "serial_number": 212345678,
+                    "manufacturer_code": "0000",
+                    "type_code": 1500,
+                    "hardware_version": 1000,
+                    "software_version": 1000,
+                    "baud_rate": 9600,
+                }
+            ],
+        },
+        "flags": [],
+    },
+}
 
 
-class TestClient:
+# ---------------------------------------------------------------------------
+# get_account
+# ---------------------------------------------------------------------------
 
-    def test_get_account(self, httpx_mock: HTTPXMock) -> None:
+
+class TestGetAccount:
+
+    def test_returns_correct_fields(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
             url="https://api.givenergy.cloud/v1/account",
             method="GET",
-            json={
-                "data": {
-                    "id": 2,
-                    "name": "frank28.203",
-                    "first_name": "Anna",
-                    "surname": "Adams",
-                    "role": "OWNER",
-                    "email": "kelly44@allen.co.uk",
-                    "address": "Flat 60\nKyle Lights",
-                    "postcode": "SP1 1NE",
-                    "country": "UNITED_KINGDOM",
-                    "telephone_number": "0738 286 7656",
-                    "timezone": "GMT",
-                    "standard_timezone": "Europe/London",
-                }
-            },
+            json={"data": ACCOUNT_PAYLOAD},
         )
-        assert GivenergyAPIClient(api_key="some-key").get_account()
+        account = GivenergyAPIClient(api_key="some-key").get_account()
+        assert account.id == 2
+        assert account.name == "frank28.203"
+        assert account.first_name == "Anna"
+        assert account.surname == "Adams"
+        assert account.role == "OWNER"
+        assert account.email == "kelly44@allen.co.uk"
+        assert account.address == "Flat 60\nKyle Lights"
+        assert account.postcode == "SP1 1NE"
+        assert account.country == "UNITED_KINGDOM"
+        assert account.telephone_number == "0738 286 7656"
+        assert account.timezone == "GMT"
+        assert account.standard_timezone == "Europe/London"
 
-    def test_get_communication_devices(self, httpx_mock: HTTPXMock) -> None:
+    def test_sends_authorization_header(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/account",
+            method="GET",
+            json={"data": ACCOUNT_PAYLOAD},
+        )
+        GivenergyAPIClient(api_key="my-secret-key").get_account()
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.headers["Authorization"] == "Bearer my-secret-key"
+        assert request.headers["Content-Type"] == "application/json"
+        assert request.headers["Accept"] == "application/json"
+
+    def test_http_401_raises(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/account",
+            method="GET",
+            status_code=401,
+        )
+        with pytest.raises(Exception):
+            GivenergyAPIClient(api_key="bad-key").get_account()
+
+    def test_http_500_raises(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/account",
+            method="GET",
+            status_code=500,
+        )
+        with pytest.raises(Exception):
+            GivenergyAPIClient(api_key="some-key").get_account()
+
+    def test_malformed_response_missing_data_key_raises(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/account",
+            method="GET",
+            json={"not_data": {}},
+        )
+        with pytest.raises(KeyError):
+            GivenergyAPIClient(api_key="some-key").get_account()
+
+    def test_malformed_response_invalid_email_raises(self, httpx_mock: HTTPXMock) -> None:
+        bad_payload = {**ACCOUNT_PAYLOAD, "email": "not-an-email"}
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/account",
+            method="GET",
+            json={"data": bad_payload},
+        )
+        with pytest.raises(Exception):
+            GivenergyAPIClient(api_key="some-key").get_account()
+
+
+# ---------------------------------------------------------------------------
+# get_communication_devices (list)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCommunicationDevices:
+
+    def test_returns_list_of_devices(self, httpx_mock: HTTPXMock) -> None:
         httpx_mock.add_response(
             url="https://api.givenergy.cloud/v1/communication-device",
             method="GET",
-            json={
-                "data": [
-                    {
-                        "serial_number": "WF2345G123",
-                        "type": "WIFI",
-                        "firmware_version": 123,
-                        "commission_date": "2021-01-01T00:00:00Z",
-                        "inverter": {
-                            "serial": "CE2345G123",
-                            "status": "WAITING",
-                            "last_online": "2023-01-01T00:00:00Z",
-                            "last_updated": "2023-01-01T00:00:00Z",
-                            "commission_date": "2021-01-01T00:00:00Z",
-                            "info": {
-                                "battery_type": "LITHIUM",
-                                "battery": {"nominal_capacity": 110, "nominal_voltage": 51.2, "depth_of_discharge": 1},
-                                "model": "GIV-AC-3.0",
-                                "max_charge_rate": 2560,
-                            },
-                            "warranty": {"type": "Standard", "expiry_date": "2033-01-01T00:00:00Z"},
-                            "firmware_version": {"ARM": 420, "DSP": 426},
-                            "connections": {
-                                "batteries": [
-                                    {
-                                        "module_number": 1,
-                                        "serial": "BB2345G123",
-                                        "firmware_version": "1035",
-                                        "capacity": {"full": 110, "design": 110},
-                                        "cell_count": 16,
-                                        "has_usb": True,
-                                        "nominal_voltage": 51.2,
-                                    }
-                                ],
-                                "meters": [
-                                    {
-                                        "address": 1,
-                                        "serial_number": 212345678,
-                                        "manufacturer_code": "0000",
-                                        "type_code": 1500,
-                                        "hardware_version": 1000,
-                                        "software_version": 1000,
-                                        "baud_rate": 9600,
-                                    }
-                                ],
-                            },
-                            "flags": [],
-                        },
-                    }
-                ]
-            },
+            json={"data": [COMMUNICATION_DEVICE_PAYLOAD]},
         )
-        assert GivenergyAPIClient(api_key="some-key").get_communication_devices()
+        devices = GivenergyAPIClient(api_key="some-key").get_communication_devices()
+        assert len(devices) == 1
+
+    def test_returns_correct_device_fields(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device",
+            method="GET",
+            json={"data": [COMMUNICATION_DEVICE_PAYLOAD]},
+        )
+        devices = GivenergyAPIClient(api_key="some-key").get_communication_devices()
+        device = devices[0]
+        assert device.serial_number == "WF2345G123"
+        assert device.type == "WIFI"
+        assert device.firmware_version == 123
+        assert device.commission_date == dt.datetime(2021, 1, 1, tzinfo=dt.timezone.utc)
+
+    def test_returns_correct_inverter_fields(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device",
+            method="GET",
+            json={"data": [COMMUNICATION_DEVICE_PAYLOAD]},
+        )
+        inverter = GivenergyAPIClient(api_key="some-key").get_communication_devices()[0].inverter
+        assert inverter.serial == "CE2345G123"
+        assert inverter.status.value == "WAITING"
+        assert inverter.firmware_version.ARM == 420
+        assert inverter.firmware_version.DSP == 426
+        assert inverter.warranty.expiry_date == dt.datetime(2033, 1, 1, tzinfo=dt.timezone.utc)
+        assert inverter.info.model == "GIV-AC-3.0"
+        assert inverter.info.max_charge_rate == 2560
+
+    def test_returns_correct_battery_connection(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device",
+            method="GET",
+            json={"data": [COMMUNICATION_DEVICE_PAYLOAD]},
+        )
+        battery = GivenergyAPIClient(api_key="some-key").get_communication_devices()[0].inverter.connections.batteries[0]
+        assert battery.serial == "BB2345G123"
+        assert battery.module_number == 1
+        assert battery.cell_count == 16
+        assert battery.has_usb is True
+        assert battery.capacity.full == 110
+        assert battery.capacity.design == 110
+
+    def test_returns_correct_meter_connection(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device",
+            method="GET",
+            json={"data": [COMMUNICATION_DEVICE_PAYLOAD]},
+        )
+        meter = GivenergyAPIClient(api_key="some-key").get_communication_devices()[0].inverter.connections.meters[0]
+        assert meter.address == 1
+        assert meter.serial_number == 212345678
+        assert meter.manufacturer_code == "0000"
+        assert meter.baud_rate == 9600
+
+    def test_returns_empty_list(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device",
+            method="GET",
+            json={"data": []},
+        )
+        devices = GivenergyAPIClient(api_key="some-key").get_communication_devices()
+        assert devices == []
+
+    def test_sends_authorization_header(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device",
+            method="GET",
+            json={"data": []},
+        )
+        GivenergyAPIClient(api_key="my-secret-key").get_communication_devices()
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.headers["Authorization"] == "Bearer my-secret-key"
+
+    def test_http_404_raises(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device",
+            method="GET",
+            status_code=404,
+        )
+        with pytest.raises(Exception):
+            GivenergyAPIClient(api_key="some-key").get_communication_devices()
+
+
+# ---------------------------------------------------------------------------
+# get_communication_device (singular)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCommunicationDevice:
+
+    def test_returns_device_by_serial(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device/WF2345G123",
+            method="GET",
+            json={"data": COMMUNICATION_DEVICE_PAYLOAD},
+        )
+        device = GivenergyAPIClient(api_key="some-key").get_communication_device(serial_number="WF2345G123")
+        assert device.serial_number == "WF2345G123"
+        assert device.type == "WIFI"
+        assert device.inverter.serial == "CE2345G123"
+
+    def test_serial_number_used_in_url(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device/MY-SERIAL-999",
+            method="GET",
+            json={"data": {**COMMUNICATION_DEVICE_PAYLOAD, "serial_number": "MY-SERIAL-999"}},
+        )
+        device = GivenergyAPIClient(api_key="some-key").get_communication_device(serial_number="MY-SERIAL-999")
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert "MY-SERIAL-999" in str(request.url)
+        assert device.serial_number == "MY-SERIAL-999"
+
+    def test_sends_authorization_header(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device/WF2345G123",
+            method="GET",
+            json={"data": COMMUNICATION_DEVICE_PAYLOAD},
+        )
+        GivenergyAPIClient(api_key="my-secret-key").get_communication_device(serial_number="WF2345G123")
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.headers["Authorization"] == "Bearer my-secret-key"
+
+    def test_http_404_raises(self, httpx_mock: HTTPXMock) -> None:
+        httpx_mock.add_response(
+            url="https://api.givenergy.cloud/v1/communication-device/UNKNOWN",
+            method="GET",
+            status_code=404,
+        )
+        with pytest.raises(Exception):
+            GivenergyAPIClient(api_key="some-key").get_communication_device(serial_number="UNKNOWN")
+
+
+# ---------------------------------------------------------------------------
+# get_client context manager
+# ---------------------------------------------------------------------------
+
+
+class TestGetClient:
+
+    def test_yields_client_with_correct_headers(self) -> None:
+        api_client = GivenergyAPIClient(api_key="test-key-123")
+        with api_client.get_client() as client:
+            assert client.headers["Authorization"] == "Bearer test-key-123"
+            assert client.headers["Content-Type"] == "application/json"
+            assert client.headers["Accept"] == "application/json"
+
+    def test_client_is_closed_after_context_exits(self) -> None:
+        api_client = GivenergyAPIClient(api_key="test-key")
+        with api_client.get_client() as client:
+            assert not client.is_closed
+        assert client.is_closed
+
+
+# ---------------------------------------------------------------------------
+# client property
+# ---------------------------------------------------------------------------
+
+
+class TestClientProperty:
+
+    def test_returns_client_with_correct_headers(self) -> None:
+        api_client = GivenergyAPIClient(api_key="prop-key")
+        client = api_client.client
+        assert client.headers["Authorization"] == "Bearer prop-key"
+        assert client.headers["Content-Type"] == "application/json"
+        assert client.headers["Accept"] == "application/json"
+        client.close()
+
+    def test_each_access_returns_new_client(self) -> None:
+        api_client = GivenergyAPIClient(api_key="prop-key")
+        c1 = api_client.client
+        c2 = api_client.client
+        assert c1 is not c2
+        c1.close()
+        c2.close()
+
+
+# ---------------------------------------------------------------------------
+# aget_client async context manager
+# ---------------------------------------------------------------------------
+
+
+class TestAgetClient:
+
+    @pytest.mark.asyncio
+    async def test_yields_async_client_with_correct_headers(self) -> None:
+        api_client = GivenergyAPIClient(api_key="async-key")
+        async with api_client.aget_client() as client:
+            assert client.headers["Authorization"] == "Bearer async-key"
+            assert client.headers["Content-Type"] == "application/json"
+            assert client.headers["Accept"] == "application/json"
+
+    @pytest.mark.asyncio
+    async def test_async_client_is_closed_after_context_exits(self) -> None:
+        api_client = GivenergyAPIClient(api_key="async-key")
+        async with api_client.aget_client() as client:
+            assert not client.is_closed
+        assert client.is_closed
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class TestEnergyDataFlowGrouping:
+
+    def test_values(self) -> None:
+        assert EnergyDataFlowGrouping.HALF_HOURLY == 0
+        assert EnergyDataFlowGrouping.DAILY == 1
+        assert EnergyDataFlowGrouping.MONTHLY == 2
+        assert EnergyDataFlowGrouping.YEARLY == 3
+        assert EnergyDataFlowGrouping.TOTAL == 4
+
+    def test_all_members_present(self) -> None:
+        members = {e.name for e in EnergyDataFlowGrouping}
+        assert members == {"HALF_HOURLY", "DAILY", "MONTHLY", "YEARLY", "TOTAL"}
+
+
+class TestEnergyDataFlowType:
+
+    def test_values(self) -> None:
+        assert EnergyDataFlowType.PV_TO_HOME == 0
+        assert EnergyDataFlowType.PV_TO_BATTERY == 1
+        assert EnergyDataFlowType.PV_TO_GRID == 2
+        assert EnergyDataFlowType.GRID_TO_HOME == 3
+        assert EnergyDataFlowType.GRID_TO_BATTERY == 4
+        assert EnergyDataFlowType.BATTERY_TO_HOME == 5
+        assert EnergyDataFlowType.BATTERY_TO_GRID == 6
+
+    def test_all_members_present(self) -> None:
+        members = {e.name for e in EnergyDataFlowType}
+        assert members == {
+            "PV_TO_HOME",
+            "PV_TO_BATTERY",
+            "PV_TO_GRID",
+            "GRID_TO_HOME",
+            "GRID_TO_BATTERY",
+            "BATTERY_TO_HOME",
+            "BATTERY_TO_GRID",
+        }

--- a/tests/test_communication_device.py
+++ b/tests/test_communication_device.py
@@ -1,0 +1,403 @@
+import datetime as dt
+
+import pytest
+from pydantic import ValidationError
+
+from givenergy_api_client.communication_device import (
+    Battery,
+    BatteryInfo,
+    BatteryType,
+    CommunicationDevice,
+    ConnectionBattery,
+    ConnectionBatteryCapacity,
+    ConnectionMeter,
+    Connections,
+    FirmwareVersion,
+    Inverter,
+    InverterStatus,
+    Warranty,
+    WarrantyType,
+)
+
+# ---------------------------------------------------------------------------
+# Shared valid payloads
+# ---------------------------------------------------------------------------
+
+VALID_BATTERY_INFO = {"nominal_capacity": 110, "nominal_voltage": 51.2, "depth_of_discharge": 1}
+
+VALID_BATTERY = {
+    "battery_type": "LITHIUM",
+    "battery": VALID_BATTERY_INFO,
+    "model": "GIV-AC-3.0",
+    "max_charge_rate": 2560,
+}
+
+VALID_WARRANTY = {"type": "Standard", "expiry_date": "2033-01-01T00:00:00Z"}
+
+VALID_FIRMWARE_VERSION = {"ARM": 420, "DSP": 426}
+
+VALID_CONNECTION_BATTERY_CAPACITY = {"full": 110, "design": 110}
+
+VALID_CONNECTION_BATTERY = {
+    "module_number": 1,
+    "serial": "BB2345G123",
+    "firmware_version": 1035,
+    "capacity": VALID_CONNECTION_BATTERY_CAPACITY,
+    "cell_count": 16,
+    "has_usb": True,
+    "nominal_voltage": 51.2,
+}
+
+VALID_CONNECTION_METER = {
+    "address": 1,
+    "serial_number": 212345678,
+    "manufacturer_code": "0000",
+    "type_code": 1500,
+    "hardware_version": 1000,
+    "software_version": 1000,
+    "baud_rate": 9600,
+}
+
+VALID_CONNECTIONS = {
+    "batteries": [VALID_CONNECTION_BATTERY],
+    "meters": [VALID_CONNECTION_METER],
+}
+
+VALID_INVERTER = {
+    "serial": "CE2345G123",
+    "status": "WAITING",
+    "last_online": "2023-01-01T00:00:00Z",
+    "last_updated": "2023-01-01T00:00:00Z",
+    "commission_date": "2021-01-01T00:00:00Z",
+    "info": VALID_BATTERY,
+    "warranty": VALID_WARRANTY,
+    "firmware_version": VALID_FIRMWARE_VERSION,
+    "connections": VALID_CONNECTIONS,
+    "flags": [],
+}
+
+VALID_COMMUNICATION_DEVICE = {
+    "serial_number": "WF2345G123",
+    "type": "WIFI",
+    "firmware_version": 123,
+    "commission_date": "2021-01-01T00:00:00Z",
+    "inverter": VALID_INVERTER,
+}
+
+
+# ---------------------------------------------------------------------------
+# InverterStatus enum
+# ---------------------------------------------------------------------------
+
+
+class TestInverterStatus:
+
+    def test_all_values(self) -> None:
+        assert InverterStatus.NORMAL.value == "NORMAL"
+        assert InverterStatus.ERROR.value == "ERROR"
+        assert InverterStatus.LOST.value == "LOST"
+        assert InverterStatus.WAITING.value == "WAITING"
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            InverterStatus("UNKNOWN")
+
+
+# ---------------------------------------------------------------------------
+# BatteryType enum
+# ---------------------------------------------------------------------------
+
+
+class TestBatteryType:
+
+    def test_lithium_value(self) -> None:
+        assert BatteryType.LITHIUM.value == "LITHIUM"
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            BatteryType("NICKEL")
+
+
+# ---------------------------------------------------------------------------
+# WarrantyType enum
+# ---------------------------------------------------------------------------
+
+
+class TestWarrantyType:
+
+    def test_standard_value(self) -> None:
+        assert WarrantyType.Standard.value == "Standard"
+
+    def test_invalid_value_raises(self) -> None:
+        with pytest.raises(ValueError):
+            WarrantyType("Extended")
+
+
+# ---------------------------------------------------------------------------
+# BatteryInfo model
+# ---------------------------------------------------------------------------
+
+
+class TestBatteryInfo:
+
+    def test_valid_construction(self) -> None:
+        info = BatteryInfo.model_validate(VALID_BATTERY_INFO)
+        assert info.nominal_capacity == 110
+        assert info.nominal_voltage == 51.2
+        assert info.depth_of_discharge == 1
+
+    def test_is_immutable(self) -> None:
+        info = BatteryInfo.model_validate(VALID_BATTERY_INFO)
+        with pytest.raises(ValidationError):
+            info.nominal_capacity = 999  # type: ignore[misc]
+
+    def test_zero_nominal_capacity_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            BatteryInfo.model_validate({**VALID_BATTERY_INFO, "nominal_capacity": 0})
+
+    def test_negative_nominal_capacity_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            BatteryInfo.model_validate({**VALID_BATTERY_INFO, "nominal_capacity": -1})
+
+    def test_zero_nominal_voltage_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            BatteryInfo.model_validate({**VALID_BATTERY_INFO, "nominal_voltage": 0.0})
+
+    def test_negative_nominal_voltage_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            BatteryInfo.model_validate({**VALID_BATTERY_INFO, "nominal_voltage": -10.0})
+
+    def test_zero_depth_of_discharge_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            BatteryInfo.model_validate({**VALID_BATTERY_INFO, "depth_of_discharge": 0})
+
+
+# ---------------------------------------------------------------------------
+# Battery model
+# ---------------------------------------------------------------------------
+
+
+class TestBattery:
+
+    def test_valid_construction(self) -> None:
+        battery = Battery.model_validate(VALID_BATTERY)
+        assert battery.battery_type == BatteryType.LITHIUM
+        assert battery.model == "GIV-AC-3.0"
+        assert battery.max_charge_rate == 2560
+        assert battery.battery.nominal_capacity == 110
+
+    def test_invalid_battery_type_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Battery.model_validate({**VALID_BATTERY, "battery_type": "NICKEL"})
+
+    def test_is_immutable(self) -> None:
+        battery = Battery.model_validate(VALID_BATTERY)
+        with pytest.raises(ValidationError):
+            battery.model = "OTHER"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Warranty model
+# ---------------------------------------------------------------------------
+
+
+class TestWarranty:
+
+    def test_valid_construction(self) -> None:
+        warranty = Warranty.model_validate(VALID_WARRANTY)
+        assert warranty.type == WarrantyType.Standard
+        assert warranty.expiry_date == dt.datetime(2033, 1, 1, tzinfo=dt.timezone.utc)
+
+    def test_invalid_warranty_type_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Warranty.model_validate({**VALID_WARRANTY, "type": "Lifetime"})
+
+    def test_invalid_date_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Warranty.model_validate({**VALID_WARRANTY, "expiry_date": "not-a-date"})
+
+
+# ---------------------------------------------------------------------------
+# FirmwareVersion model
+# ---------------------------------------------------------------------------
+
+
+class TestFirmwareVersion:
+
+    def test_valid_construction(self) -> None:
+        fw = FirmwareVersion.model_validate(VALID_FIRMWARE_VERSION)
+        assert fw.ARM == 420
+        assert fw.DSP == 426
+
+    def test_zero_arm_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            FirmwareVersion.model_validate({"ARM": 0, "DSP": 426})
+
+    def test_negative_dsp_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            FirmwareVersion.model_validate({"ARM": 420, "DSP": -1})
+
+
+# ---------------------------------------------------------------------------
+# ConnectionBatteryCapacity model
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionBatteryCapacity:
+
+    def test_valid_construction(self) -> None:
+        cap = ConnectionBatteryCapacity.model_validate(VALID_CONNECTION_BATTERY_CAPACITY)
+        assert cap.full == 110
+        assert cap.design == 110
+
+    def test_zero_full_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ConnectionBatteryCapacity.model_validate({"full": 0, "design": 110})
+
+    def test_zero_design_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ConnectionBatteryCapacity.model_validate({"full": 110, "design": 0})
+
+
+# ---------------------------------------------------------------------------
+# ConnectionBattery model
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionBattery:
+
+    def test_valid_construction(self) -> None:
+        bat = ConnectionBattery.model_validate(VALID_CONNECTION_BATTERY)
+        assert bat.serial == "BB2345G123"
+        assert bat.module_number == 1
+        assert bat.cell_count == 16
+        assert bat.has_usb is True
+        assert bat.nominal_voltage == 51.2
+        assert bat.capacity.full == 110
+
+    def test_zero_module_number_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ConnectionBattery.model_validate({**VALID_CONNECTION_BATTERY, "module_number": 0})
+
+    def test_negative_nominal_voltage_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ConnectionBattery.model_validate({**VALID_CONNECTION_BATTERY, "nominal_voltage": -1.0})
+
+    def test_is_immutable(self) -> None:
+        bat = ConnectionBattery.model_validate(VALID_CONNECTION_BATTERY)
+        with pytest.raises(ValidationError):
+            bat.serial = "OTHER"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# ConnectionMeter model
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionMeter:
+
+    def test_valid_construction(self) -> None:
+        meter = ConnectionMeter.model_validate(VALID_CONNECTION_METER)
+        assert meter.address == 1
+        assert meter.serial_number == 212345678
+        assert meter.manufacturer_code == "0000"
+        assert meter.type_code == 1500
+        assert meter.hardware_version == 1000
+        assert meter.software_version == 1000
+        assert meter.baud_rate == 9600
+
+    def test_zero_address_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ConnectionMeter.model_validate({**VALID_CONNECTION_METER, "address": 0})
+
+    def test_zero_baud_rate_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            ConnectionMeter.model_validate({**VALID_CONNECTION_METER, "baud_rate": 0})
+
+
+# ---------------------------------------------------------------------------
+# Connections model
+# ---------------------------------------------------------------------------
+
+
+class TestConnections:
+
+    def test_valid_construction(self) -> None:
+        conn = Connections.model_validate(VALID_CONNECTIONS)
+        assert len(conn.batteries) == 1
+        assert len(conn.meters) == 1
+
+    def test_empty_batteries_and_meters(self) -> None:
+        conn = Connections.model_validate({"batteries": [], "meters": []})
+        assert conn.batteries == []
+        assert conn.meters == []
+
+    def test_multiple_batteries(self) -> None:
+        second_battery = {**VALID_CONNECTION_BATTERY, "module_number": 2, "serial": "BB9999X999"}
+        conn = Connections.model_validate({"batteries": [VALID_CONNECTION_BATTERY, second_battery], "meters": []})
+        assert len(conn.batteries) == 2
+
+
+# ---------------------------------------------------------------------------
+# Inverter model
+# ---------------------------------------------------------------------------
+
+
+class TestInverter:
+
+    def test_valid_construction(self) -> None:
+        inverter = Inverter.model_validate(VALID_INVERTER)
+        assert inverter.serial == "CE2345G123"
+        assert inverter.status == InverterStatus.WAITING
+        assert inverter.last_online == dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+        assert inverter.last_updated == dt.datetime(2023, 1, 1, tzinfo=dt.timezone.utc)
+        assert inverter.commission_date == dt.datetime(2021, 1, 1, tzinfo=dt.timezone.utc)
+        assert inverter.flags == []
+
+    def test_invalid_status_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            Inverter.model_validate({**VALID_INVERTER, "status": "CHARGING"})
+
+    def test_all_inverter_statuses_accepted(self) -> None:
+        for status in ("NORMAL", "ERROR", "LOST", "WAITING"):
+            inverter = Inverter.model_validate({**VALID_INVERTER, "status": status})
+            assert inverter.status == InverterStatus(status)
+
+    def test_is_immutable(self) -> None:
+        inverter = Inverter.model_validate(VALID_INVERTER)
+        with pytest.raises(ValidationError):
+            inverter.serial = "OTHER"  # type: ignore[misc]
+
+    def test_flags_can_contain_strings(self) -> None:
+        inverter = Inverter.model_validate({**VALID_INVERTER, "flags": ["FLAG_A", "FLAG_B"]})
+        assert inverter.flags == ["FLAG_A", "FLAG_B"]
+
+
+# ---------------------------------------------------------------------------
+# CommunicationDevice model
+# ---------------------------------------------------------------------------
+
+
+class TestCommunicationDevice:
+
+    def test_valid_construction(self) -> None:
+        device = CommunicationDevice.model_validate(VALID_COMMUNICATION_DEVICE)
+        assert device.serial_number == "WF2345G123"
+        assert device.firmware_version == 123
+        assert device.type == "WIFI"
+        assert device.commission_date == dt.datetime(2021, 1, 1, tzinfo=dt.timezone.utc)
+        assert device.inverter.serial == "CE2345G123"
+
+    def test_missing_inverter_raises(self) -> None:
+        incomplete = {k: v for k, v in VALID_COMMUNICATION_DEVICE.items() if k != "inverter"}
+        with pytest.raises(ValidationError):
+            CommunicationDevice.model_validate(incomplete)
+
+    def test_is_immutable(self) -> None:
+        device = CommunicationDevice.model_validate(VALID_COMMUNICATION_DEVICE)
+        with pytest.raises(ValidationError):
+            device.serial_number = "OTHER"  # type: ignore[misc]
+
+    def test_invalid_commission_date_raises(self) -> None:
+        with pytest.raises(ValidationError):
+            CommunicationDevice.model_validate({**VALID_COMMUNICATION_DEVICE, "commission_date": "not-a-date"})


### PR DESCRIPTION
- Rewrote test_client.py: added field-level assertions to existing tests,
  added tests for get_communication_device (singular), HTTP error responses
  (401, 404, 500), empty-list edge cases, authorization header verification,
  get_client context manager lifecycle, client property, aget_client async
  context manager, and both energy-flow enums
- Added tests/test_account.py: validates Account model construction,
  immutability, EmailStr validation, missing-field errors, and email
  domain normalisation
- Added tests/test_communication_device.py: validates all nested models
  (BatteryInfo, Battery, Warranty, FirmwareVersion, ConnectionBattery,
  ConnectionMeter, Connections, Inverter, CommunicationDevice) plus all
  three enums (InverterStatus, BatteryType, WarrantyType), covering
  positive and negative cases including PositiveInt/PositiveFloat constraints

https://claude.ai/code/session_01SaiuQ5M8o8F9jGDYHiT512