### PR TITLE
ci: force Node 24 for all GitHub Actions workflows

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -13,6 +13,9 @@ on:
       - "pyproject.toml"
       - "uv.lock"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -15,6 +15,9 @@ on:
       - "uv.lock"
       - ".pre-commit-config.yaml"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_documentation.yml
+++ b/.github/workflows/deploy_documentation.yml
@@ -7,6 +7,9 @@ on:
       - "mkdocs.yml"
       - "uv.lock"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 permissions:
   contents: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release-build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ on:
       - "pyproject.toml"
       - "uv.lock"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   ci:
     strategy:


### PR DESCRIPTION
## Summary
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env var to all five CI workflows
- Suppresses Node 20 deprecation warnings from bundled GitHub Actions
- No functional changes to build, test, or publish logic

## Test plan
- [ ] Verify CI workflows run without Node deprecation warnings after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)